### PR TITLE
Ensure the lowest index duplicate is the one that is kept

### DIFF
--- a/src/packing.cpp
+++ b/src/packing.cpp
@@ -155,16 +155,19 @@ namespace {
 
     // sort duplicates to back
     auto unique_sprites = sprites;
-    for (auto i = size_t{ }; i < unique_sprites.size(); ++i) {
-      for (auto j = size_t{ }; j < i; ++j)
+    for (auto i = sprites.size()-1; ; --i) {
+      for (auto j = size_t{ }; j < i; ++j) {
         if (is_identical(*sprites[i].source, sprites[i].trimmed_source_rect,
                          *sprites[j].source, sprites[j].trimmed_source_rect)) {
           sprites[i].duplicate_of_index = sprites[j].index;
-          std::swap(sprites[i--], unique_sprites.back());
+          std::swap(sprites[i], unique_sprites.back());
           unique_sprites = unique_sprites.first(unique_sprites.size() - 1);
           break;
         }
-       }
+      }
+      if (i == 0)
+        break;
+    }
 
     // restore order of unique sprites before packing
     std::sort(unique_sprites.begin(), unique_sprites.end(),


### PR DESCRIPTION
I'm looking into using spright to merge and deduplicate a bunch of tilesets for use in [ldtk](https://ldtk.io/), which has a very simple notion of what a tileset is (one image for a tileset, one tileset per layer, tiles identified by position in image). Using spright is a bit overkill for this, but I want to use it for the more advanced features for other assets, so it seems nice to be consistent.

It seems that using `rows` packing (or `columns` I guess), a fixed `width`/`max-width`, deduplication, and no trimming should create a stable output, in the sense that adding a new `input` at the end of the configuration file shouldn't move previous tiles. Unfortunately this is only *almost* the case, because deduplication doesn't actually ensure that the same tile is kept. This PR changes that, making it so that `duplicate_of_index <= index` holds for all sprites.

I'm using this patch locally, but I figured it might be interesting for others as well.