### PR TITLE
Update CMakeLists.txt to support MinGW-w64 builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,10 +73,12 @@ elseif(WIN32)
         libs/utf8_console/utf8_console.cpp
     )
 
-    add_compile_options(/GR- /GL /Os /MP /W3 /wd4100)
-    add_link_options($<$<CONFIG:RELEASE>:/LTCG>)
-    add_compile_options($<$<CONFIG:RELEASE>:/MT>)
-    add_compile_definitions(_CRT_SECURE_NO_WARNINGS _CRT_NONSTDC_NO_WARNINGS)
+    if(MSVC)
+        add_compile_options(/GR- /GL /Os /MP /W3 /wd4100)
+        add_link_options($<$<CONFIG:RELEASE>:/LTCG>)
+        add_compile_options($<$<CONFIG:RELEASE>:/MT>)
+        add_compile_definitions(_CRT_SECURE_NO_WARNINGS _CRT_NONSTDC_NO_WARNINGS)
+    endif()
 endif()
 
 include_directories(.)


### PR DESCRIPTION
Hide MSVC-specifics using `if(MSVC)`